### PR TITLE
Separate directory for xdebug output

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -19,6 +19,8 @@ COPY --chown=skpr:skpr conf.d /etc/php/conf.d
 
 ENV PHP_FPM_REQUEST_TIMEOUT 600
 
-ENV XDEBUG_MODE=debug
+VOLUME /tmp/xdebug
+RUN chown -R skpr:skpr /tmp/xdebug
 
 USER skpr
+

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -19,4 +19,7 @@ COPY --chown=skpr:skpr conf.d /etc/php/conf.d
 
 ENV PHP_FPM_REQUEST_TIMEOUT 600
 
+ENV XDEBUG_MODE=debug
+ENV XDEBUG_OUTPUT_DIR=tmp
+
 USER skpr

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -20,6 +20,5 @@ COPY --chown=skpr:skpr conf.d /etc/php/conf.d
 ENV PHP_FPM_REQUEST_TIMEOUT 600
 
 ENV XDEBUG_MODE=debug
-ENV XDEBUG_OUTPUT_DIR=tmp
 
 USER skpr

--- a/dev/conf.d/01_xdebug.ini
+++ b/dev/conf.d/01_xdebug.ini
@@ -1,4 +1,3 @@
 zend_extension=xdebug.so
 xdebug.mode="${XDEBUG_MODE}"
-xdebug.output_dir=${XDEBUG_OUTPUT_DIR}
 xdebug.client_host=host.docker.internal

--- a/dev/conf.d/01_xdebug.ini
+++ b/dev/conf.d/01_xdebug.ini
@@ -1,3 +1,4 @@
 zend_extension=xdebug.so
-xdebug.mode=debug
+xdebug.mode="${XDEBUG_MODE}"
+xdebug.output_dir=${XDEBUG_OUTPUT_DIR}
 xdebug.client_host=host.docker.internal

--- a/dev/conf.d/01_xdebug.ini
+++ b/dev/conf.d/01_xdebug.ini
@@ -1,3 +1,4 @@
 zend_extension=xdebug.so
-xdebug.mode="${XDEBUG_MODE}"
+xdebug.mode=debug
+xdebug.output_dir=/tmp/xdebug
 xdebug.client_host=host.docker.internal


### PR DESCRIPTION
Allows developers to get xdebug output files (profiles).

```yml
volumes:
  # Adds a hidden xdebug directory for temporary files.
  - ./.xdebug:/tmp/xdebug
```