### PR TITLE
Allow chdir override

### DIFF
--- a/fpm/php-fpm.conf
+++ b/fpm/php-fpm.conf
@@ -5,7 +5,7 @@ log_limit = ${PHP_FPM_LOG_LIMIT}
 [www]
 listen = [::]:${PHP_FPM_PORT}
 
-chdir = /data/app
+chdir = ${PHP_FPM_CHDIR:-/data/app}
 
 pm = dynamic
 pm.max_children      = ${PHP_FPM_MAX_CHILDREN}


### PR DESCRIPTION
SNSW GEL uses a custom php-fpm.conf to override this variable. It'd be nice to be able to set it via an environment variable with the existing value as a default.