### PR TITLE
Throw exceptions on failed asserts

### DIFF
--- a/circleci/fpm/conf.d/50_fpm.ini
+++ b/circleci/fpm/conf.d/50_fpm.ini
@@ -2,3 +2,5 @@ date.timezone = "UTC"
 short_open_tag = Off
 session.auto_start = Off
 max_execution_time = 300
+assert.exception = 1
+zend.assertions = 1

--- a/dev/conf.d/50_dev.ini
+++ b/dev/conf.d/50_dev.ini
@@ -6,3 +6,4 @@ html_errors = On
 session.gc_probability = 1
 max_execution_time = 0
 assert.exception = 1
+zend.assertions = 1


### PR DESCRIPTION
Without this, we don't get an exception thrown when an assert fails.

This was reverted in https://github.com/skpr/image-php/commit/2455bf83c69d0dc94c9bc660774894629ff6a00a but I'm not sure why.