### PR TITLE
Move less to cli image for dev and non-dev

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -4,7 +4,7 @@ ARG ARCH=amd64
 
 FROM alpine:${ALPINE_VERSION} as redis-cli
 
-RUN apk add redis
+RUN apk add redis less
 
 FROM ${IMAGE}
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -6,7 +6,7 @@ ARG ARCH=amd64
 
 USER root
 
-RUN apk add php${PHP_VERSION}-xdebug less
+RUN apk add php${PHP_VERSION}-xdebug
 
 # https://blog.blackfire.io/alpine-linux-support.html
 RUN curl -sSL -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${ARCH}/${PHP_VERSION//./} && \


### PR DESCRIPTION
We need `less` on both dev and non-dev CLI images.