### PR TITLE
Enable secure cookies by default

### DIFF
--- a/base/conf.d/50_overrides.ini
+++ b/base/conf.d/50_overrides.ini
@@ -12,3 +12,6 @@ opcache.max_accelerated_files = 30000
 
 # Increase maximum length of logs.
 log_errors_max_len = ${PHP_LOG_LIMIT}
+
+# Enable secure cookies by default
+session.cookie_httponly = true


### PR DESCRIPTION
> An HTTP cookie is a small piece of information that a server sends to the user’s web browser. The Cookie header stores the HTTP cookies previously sent by the web server with the Set-Cookie header.
> 
> The session cookies are deleted when the browser shuts down and if the cookies are permanent, they will expire at the time defined by Expires or Max-Age.
> 
> The risk of client-side scripts accessing the protected cookie can be mitigated by including an additional “HttpOnly” flag in the Set-Cookie HTTP response header.
> 
> As a result, the browser will not reveal the cookie to a third party even if a cross-site scripting (XSS) flaw exists in the web application.

https://support.detectify.com/support/solutions/articles/48001048952-missing-httponly-flag-on-cookies