### PR TITLE
Add findutils to circleci image

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -13,7 +13,8 @@ USER root
 
 RUN apk --update --no-cache add \
   php${PHP_VERSION}-fpm \
-  openssh-client
+  openssh-client \
+  findutils
 
 COPY fpm/conf.d/50_fpm.ini /etc/php/conf.d/50_fpm.ini
 COPY fpm/php-fpm.conf /etc/php/php-fpm.conf


### PR DESCRIPTION
This installs the GNU version of `xargs` required for [rerunning failed tests](https://circleci.com/docs/rerun-failed-tests/).