### PR TITLE
Plugin caching_sha2_password could not be loaded

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -60,6 +60,7 @@ RUN apk --update --no-cache add \
       pngquant \
       jpegoptim \
       mysql-client \
+      mariadb-connector-c \
       optipng \
       tesseract-ocr \
       tesseract-ocr-dev \


### PR DESCRIPTION
Fixes the following issue:

```
$ drush sql:cli
ERROR 1045 (28000): Plugin caching_sha2_password could not be loaded: Error loading shared library /usr/lib/mariadb/plugin/caching_sha2_password.so: No such file or directory
```