### PR TITLE
Add posix-compliant tar

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -29,6 +29,7 @@ RUN apk --update --no-cache add \
       openssh-client \
       patch \
       rsync \
+      tar \
       vim
 
 RUN curl -sS https://getcomposer.org/download/latest-1.x/composer.phar -o /usr/local/bin/composer1 && \


### PR DESCRIPTION
Busybox tar is not able to create posix format tar files. This causes cache actions in github actions to fail.