### PR TITLE
Fix: Sends fpm logs to stdout

### DIFF
--- a/fpm/php-fpm.conf
+++ b/fpm/php-fpm.conf
@@ -1,5 +1,5 @@
 [global]
-error_log = /proc/self/fd/2
+error_log = /proc/self/fd/1
 log_limit = ${PHP_FPM_LOG_LIMIT}
 
 [www]
@@ -17,7 +17,7 @@ pm.max_requests      = ${PHP_FPM_MAX_REQUESTS}
 pm.status_path = /status
 
 access.format='{ "timestamp": "%{%Y-%m-%dT%H:%M:%S%z}T", "fields": { "client_ip": "%{HTTP_X_FORWARDED_FOR}e", "remote_addr": "%R", "remote_user": "%u", "request_uri": "%{REQUEST_URI}e", "status": "%s", "body_bytes_sent": "%l", "request_time": "%d", "http_referrer": "%{HTTP_REFERER}e", "http_user_agent": "%{HTTP_USER_AGENT}e", "request_id": "%{HTTP_X_REQUEST_ID}e", "cpu": "%C", "memory": "%M", "headers": { "Cache-Control": "%{Cache-Control}o"} } }'
-access.log = /proc/self/fd/2
+access.log = /proc/self/fd/1
 
 clear_env = no
 


### PR DESCRIPTION
### **Overview:**
FPM logs are cluttering the Drupal Logs and we want to be able to only see fpm logs or drupal logs as needed for better readability.

### **Solution**
Sending the FPM logs to stdout so that we can stream them separately to application logs.