### PR TITLE
Fix for WARNING: Nothing matches the include pattern

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -9,7 +9,9 @@ COPY conf.d/50_fpm.ini /etc/php/conf.d/50_fpm.ini
 COPY php-fpm.conf /etc/php/php-fpm.conf
 
 # Ensure the FPM configuration directory is empty.
-RUN rm -f /etc/php/php-fpm.d/*.conf
+# Create an empty file to ensure there are no warnings.
+RUN rm -f /etc/php/php-fpm.d/*.conf && \
+    touch /etc/php/php-fpm.d/empty.conf
 
 EXPOSE 9000
 

--- a/fpm/tests.yml
+++ b/fpm/tests.yml
@@ -4,3 +4,4 @@ commandTests:
   - name: 'check configuration'
     command: "sh"
     args: ["-c", "mkdir /data/app && php-fpm --test"]
+    excludedError: [".*WARNING.*"]


### PR DESCRIPTION
**What this does**

* Adds a test to catch warnings
* Fixes `WARNING: Nothing matches the include pattern '/etc/php/php-fpm.d/*.conf' from /etc/php/php-fpm.conf at line 29`