### PR TITLE
Adjust FPM log limit to avoid trimming

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -20,7 +20,7 @@ USER skpr
 # Configuration which can be overriden.
 # See /etc/php/php-fpm.conf
 ENV PHP_FPM_PORT=9000 \
-    PHP_FPM_LOG_LIMIT=4096 \
+    PHP_FPM_LOG_LIMIT=32768 \
     PHP_FPM_MAX_CHILDREN=20 \
     PHP_FPM_START_SERVERS=2 \
     PHP_FPM_MIN_SPARE_SERVERS=2 \


### PR DESCRIPTION
**Overview**

We have seen issues where stacktraces are being trimmed and split into multiple separate lines.

**Solution**

Bump the size of the allowed log.

We have chosen a x4 bump based on logs we have seen on client environments.

I have also checked if we will be blocked by CloudWatch logs.

CloudWatch logs has a limit of 256KB (262,144 characters) which is well above what we are setting here.