### PR TITLE
chore: updates image tags from latest to stable and edge to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,29 +37,6 @@ workflows:
             branches:
               ignore: [ main, releases ]
 
-  build_edge:
-    jobs:
-      - build:
-          stream: edge
-          context: docker-publishing
-          matrix:
-            parameters:
-              php_version: *php_versions
-              executor: *platforms
-          filters:
-            branches:
-              only: [ main ]
-      - manifest:
-          stream: edge
-          context: docker-publishing
-          matrix:
-            parameters:
-              php_version: *php_versions
-          requires: [ build ]
-          filters:
-            branches:
-              only: [ main ]
-
   build_latest:
     jobs:
       - build:
@@ -71,7 +48,7 @@ workflows:
               executor: *platforms
           filters:
             branches:
-              only: [ releases ]
+              only: [ main ]
       - manifest:
           stream: latest
           context: docker-publishing
@@ -81,12 +58,35 @@ workflows:
           requires: [ build ]
           filters:
             branches:
-              only: [ releases ]
+              only: [ main ]
 
-  nightly_edge:
+  build_stable:
     jobs:
       - build:
-          stream: edge
+          stream: stable
+          context: docker-publishing
+          matrix:
+            parameters:
+              php_version: *php_versions
+              executor: *platforms
+          filters:
+            branches:
+              only: [ releases ]
+      - manifest:
+          stream: stable
+          context: docker-publishing
+          matrix:
+            parameters:
+              php_version: *php_versions
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_latest:
+    jobs:
+      - build:
+          stream: latest
           context: docker-publishing
           matrix:
             parameters:
@@ -96,7 +96,7 @@ workflows:
             branches:
               only: [ main ]
       - manifest:
-          stream: edge
+          stream: latest
           context: docker-publishing
           matrix:
             parameters:
@@ -113,10 +113,10 @@ workflows:
             branches:
               only: [ main ]
 
-  nightly_latest:
+  nightly_stable:
     jobs:
       - build:
-          stream: latest
+          stream: stable
           context: docker-publishing
           matrix:
             parameters:
@@ -126,7 +126,7 @@ workflows:
             branches:
               only: [ releases ]
       - manifest:
-          stream: latest
+          stream: stable
           context: docker-publishing
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,10 @@ workflows:
             branches:
               ignore: [ main, releases ]
 
-  build_latest:
+  build_edge:
     jobs:
       - build:
-          stream: latest
+          stream: edge
           context: docker-publishing
           matrix:
             parameters:
@@ -50,7 +50,7 @@ workflows:
             branches:
               only: [ main ]
       - manifest:
-          stream: latest
+          stream: edge
           context: docker-publishing
           matrix:
             parameters:
@@ -83,7 +83,7 @@ workflows:
             branches:
               only: [ releases ]
 
-  nightly_latest:
+  build_latest:
     jobs:
       - build:
           stream: latest
@@ -94,9 +94,32 @@ workflows:
               executor: *platforms
           filters:
             branches:
-              only: [ main ]
+              only: [ releases ]
       - manifest:
           stream: latest
+          context: docker-publishing
+          matrix:
+            parameters:
+              php_version: *php_versions
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_edge:
+    jobs:
+      - build:
+          stream: edge
+          context: docker-publishing
+          matrix:
+            parameters:
+              php_version: *php_versions
+              executor: *platforms
+          filters:
+            branches:
+              only: [ main ]
+      - manifest:
+          stream: edge
           context: docker-publishing
           matrix:
             parameters:
@@ -135,6 +158,30 @@ workflows:
           filters:
             branches:
               only: [ releases ]
+
+  nightly_latest:
+    jobs:
+      - build:
+          stream: latest
+          context: docker-publishing
+          matrix:
+            parameters:
+              php_version: *php_versions
+              executor: *platforms
+          filters:
+            branches:
+              only: [ releases ]
+      - manifest:
+          stream: latest
+          context: docker-publishing
+          matrix:
+            parameters:
+              php_version: *php_versions
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+
     triggers:
       - schedule:
           # Scheduled build for 2am AEST nightly.


### PR DESCRIPTION
## Overview

Update Image tags from `edge` to `latest` and update `latest` to `stable`

## Implementation

I've updated the image tags and even stage names to reflect the change

## How to Test

Running the build pipeline will build the tags as intended

## What is the rollout plan?

We need to update skpr to use the new image tags and for those projects not on skpr update their pipelines. 

## Does this change need a blog post?

No

## Link to Tickets

* https://previousnext.atlassian.net/browse/SKPR-958 