### PR TITLE
Disable Opcache Timestamp Validation

### DIFF
--- a/base/conf.d/50_overrides.ini
+++ b/base/conf.d/50_overrides.ini
@@ -10,5 +10,8 @@ upload_max_filesize = 20M
 # Increase max_accelerated_files to better match Drupal.
 opcache.max_accelerated_files = 30000
 
+# Increase the amount of memory used for interned strings.
+opcache.interned_strings_buffer=64
+
 # Increase maximum length of logs.
 log_errors_max_len = ${PHP_LOG_LIMIT}

--- a/fpm/conf.d/50_fpm.ini
+++ b/fpm/conf.d/50_fpm.ini
@@ -3,3 +3,5 @@ short_open_tag = Off
 session.auto_start = Off
 max_execution_time = 300
 fastcgi.logging = Off
+# Files never change in production
+opcache.validate_timestamps=0


### PR DESCRIPTION
* Avoid uncessary filesystem calls
* Increase interned string buffer

https://www.drupal.org/project/drupal/issues/3108687#comment-15780373
https://tideways.com/profiler/blog/fine-tune-your-opcache-configuration-to-avoid-caching-suprises
https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.validate-timestamps
