### PR TITLE
Update the docker version of the manifest task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,8 @@ jobs:
       - image: cimg/base:2024.09
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: previous
       - run:
           name: Push Manifest
           command: |


### PR DESCRIPTION
I'd like another stable release soon, but unfortunately manifest jobs are failing.
This PR will address the problem, as can be seen in CircleCI below:

![image](https://github.com/user-attachments/assets/aba88063-21cf-4846-81de-80b15152652c)
