### PR TITLE
chore: bump skprmail in base image to 1.0.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -67,7 +67,7 @@ RUN apk --update --no-cache add \
       poppler-utils \
       libsodium
 
-RUN export SKPRMAIL_VERSION=0.0.14 && \
+RUN export SKPRMAIL_VERSION=1.0.0 && \
     curl -sSL https://github.com/skpr/mail/releases/download/v${SKPRMAIL_VERSION}/skprmail_${SKPRMAIL_VERSION}_linux_${ARCH} -o /usr/local/bin/skprmail && \
     chmod +rx /usr/local/bin/skprmail
 


### PR DESCRIPTION
Update skprmail to latest version that uses go 1.23.1 and alpine 3.20