### PR TITLE
Bump New Relic to 11.5.0.18

### DIFF
--- a/newrelic/Dockerfile
+++ b/newrelic/Dockerfile
@@ -9,7 +9,7 @@ ENV NEW_RELIC_ENABLED=false
 
 RUN export NR_INSTALL_SILENT=true && \
     export NR_INSTALL_USE_CP_NOT_LN=true && \
-    export NR_VERSION=11.3.0.16 && \
+    export NR_VERSION=11.5.0.18 && \
     export NR_FILENAME=newrelic-php5-${NR_VERSION}-linux-musl && \
     curl -sSL https://download.newrelic.com/php_agent/archive/${NR_VERSION}/${NR_FILENAME}.tar.gz | gzip -dc | tar xf - && \
     cd ${NR_FILENAME} && ./newrelic-install install && \


### PR DESCRIPTION
Adds support for PHP 8.4

https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/