### PR TITLE
Bump New Relic to v12.0.0.25

### DIFF
--- a/newrelic/Dockerfile
+++ b/newrelic/Dockerfile
@@ -9,7 +9,7 @@ ENV NEW_RELIC_ENABLED=false
 
 RUN export NR_INSTALL_SILENT=true && \
     export NR_INSTALL_USE_CP_NOT_LN=true && \
-    export NR_VERSION=11.6.0.19 && \
+    export NR_VERSION=12.0.0.25 && \
     export NR_FILENAME=newrelic-php5-${NR_VERSION}-linux-musl && \
     curl -sSL https://download.newrelic.com/php_agent/archive/${NR_VERSION}/${NR_FILENAME}.tar.gz | gzip -dc | tar xf - && \
     cd ${NR_FILENAME} && ./newrelic-install install && \


### PR DESCRIPTION
https://github.com/newrelic/newrelic-php-agent/releases/tag/v12.0.0.25