### PR TITLE
Set a Same Site Cookie default value

### DIFF
--- a/fpm/conf.d/50_fpm.ini
+++ b/fpm/conf.d/50_fpm.ini
@@ -1,5 +1,6 @@
 date.timezone = "UTC"
-short_open_tag = Off
-session.auto_start = Off
-max_execution_time = 300
 fastcgi.logging = Off
+max_execution_time = 300
+session.auto_start = Off
+session.cookie_samesite=Lax
+short_open_tag = Off


### PR DESCRIPTION
Drupal throws a warning if this setting is not set. `Lax` seems to be the most recommened, so lets set it to that by default.